### PR TITLE
Prevent search misses via an exhaustive placeholder

### DIFF
--- a/src/components/Nav.js
+++ b/src/components/Nav.js
@@ -38,7 +38,7 @@ export default ({ navigate, version }: NavigateProps) => (
           tabIndex="100"
           type="text"
           onChange={({ target: { value } }) => navigate(value)}
-          placeholder="Command name"
+          placeholder="Command (i.e. 'git') optionally prefixed by the OS (i.e. 'osx/mas' ; supported OS: android, common, linux, osx, sunos and windows)."
         />
       </section>
       <section className="github-stars">


### PR DESCRIPTION
The goal is to prevent search misses from the live demo in https://tldr.sh like this (see https://github.com/tldr-pages/tldr/pull/6269):
![image](https://user-images.githubusercontent.com/3862051/127603267-0293858f-d085-4ba1-b5d2-8d8efc4b64be.png)


