### PR TITLE
Prevent search misses via input's placeholder/tooltip

### DIFF
--- a/src/components/Nav.js
+++ b/src/components/Nav.js
@@ -38,7 +38,8 @@ export default ({ navigate, version }: NavigateProps) => (
           tabIndex="100"
           type="text"
           onChange={({ target: { value } }) => navigate(value)}
-          placeholder="Command name"
+          placeholder="i.e. man, linux/du, osx/say..."
+          title="Command optionally prefixed by the platform and a slash (supported platforms: android, common, linux, osx, sunos and windows)."
         />
       </section>
       <section className="github-stars">

--- a/styles/navigation.sass
+++ b/styles/navigation.sass
@@ -56,13 +56,13 @@ nav
     +adaptive("margin-left", 5px, 30px, 30px)
 
     height: 38px
-    +adaptive("width", 165px, 220px, 220px)
+    +adaptive("width", 165px, 250px, 250px)
     +adaptive("max-width", 165px, 60%, 60%)
 
     border: 1px solid $outline
     border-radius: 0px
 
-    font-size: 16pt
+    font-size: 11pt
     +adaptive("padding", 0px 6px, 0px 12px, 0px 12px)
 
     &:focus


### PR DESCRIPTION
In order to prevent search misses (like @mathieupouedras and I did in https://github.com/tldr-pages/tldr/pull/6269):
- [x] Reduce search input font size and use a more concrete value for the placeholder.
- [x] Add a tooltip

Screen shot on my laptop:
<img width="612" alt="Screenshot 2021-08-02 at 05 43 50" src="https://user-images.githubusercontent.com/3862051/127801894-b7a3084a-5b7c-4fde-942a-83788d668826.png">

Preview on a small iPhone:
<img width="276" alt="Screenshot 2021-08-02 at 05 46 09" src="https://user-images.githubusercontent.com/3862051/127801895-38ffa0b7-f407-430a-bd7e-9a037c9eee25.png">

Preview on a small Android:
<img width="303" alt="Screenshot 2021-08-02 at 05 46 32" src="https://user-images.githubusercontent.com/3862051/127801896-e1c96f8f-3d7b-4dc3-a9e9-708dac6f58e8.png">


